### PR TITLE
[ET-152] default to sha256 in xmerl_dsig:digest/1

### DIFF
--- a/src/xmerl_dsig.erl
+++ b/src/xmerl_dsig.erl
@@ -136,7 +136,7 @@ sign(ElementIn, PrivateKey = #'RSAPrivateKey'{}, CertBin, SigMethod) when is_bin
 %% Strips any XML digital signatures and applies any relevant InclusiveNamespaces
 %% before generating the digest.
 -spec digest(Element :: #xmlElement{}) -> binary().
-digest(Element) -> digest(Element, sha).
+digest(Element) -> digest(Element, sha256).
 
 -spec digest(Element :: #xmlElement{}, HashFunction :: sha | sha256) -> binary().
 digest(Element, HashFunction) ->


### PR DESCRIPTION
This is made use of in checking duplicate assertions (ET-152), and [_Thou shalt not SHA1_](https://security.googleblog.com/2014/09/gradually-sunsetting-sha-1.html).
