### PR TITLE
[ET-154] Decode and track RequestIds

### DIFF
--- a/include/esaml.hrl
+++ b/include/esaml.hrl
@@ -59,6 +59,7 @@
 	version = "2.0" :: esaml:version(),
 	issue_instant = "" :: esaml:datetime(),
 	recipient = "" :: string(),
+	in_response_to :: string() | undefined,
 	issuer = "" :: string(),
 	subject = #esaml_subject{} :: esaml:subject(),
 	conditions = [] :: esaml:conditions(),
@@ -82,6 +83,7 @@
 -record(esaml_response, {
 	version = "2.0" :: esaml:version(),
 	issue_instant = "" :: esaml:datetime(),
+	in_response_to :: string() | undefined,
 	destination = "" :: string(),
 	issuer = "" :: string(),
 	status = unknown :: esaml:status_code(),

--- a/src/esaml.erl
+++ b/src/esaml.erl
@@ -17,7 +17,8 @@
 
 -export([start/2, stop/1, init/1]).
 -export([stale_time/1]).
--export([config/2, config/1, to_xml/1, decode_response/1, decode_assertion/1, validate_assertion/3]).
+-export([config/2, config/1, to_xml/1, decode_response/1, decode_assertion/1]).
+-export([validate_assertion/3, validate_assertion/4]).
 -export([decode_logout_request/1, decode_logout_response/1, decode_idp_metadata/1]).
 
 -type org() :: #esaml_org{}.
@@ -227,6 +228,7 @@ decode_response(Xml) ->
     esaml_util:threaduntil([
         ?xpath_attr_required("/samlp:Response/@Version", esaml_response, version, bad_version),
         ?xpath_attr_required("/samlp:Response/@IssueInstant", esaml_response, issue_instant, bad_response),
+        ?xpath_attr("/samlp:Response/@InResponseTo", esaml_response, in_response_to),
         ?xpath_attr("/samlp:Response/@Destination", esaml_response, destination),
         ?xpath_text("/samlp:Response/saml:Issuer/text()", esaml_response, issuer),
         ?xpath_attr("/samlp:Response/samlp:Status/samlp:StatusCode/@Value", esaml_response, status, fun status_code_map/1),
@@ -242,6 +244,7 @@ decode_assertion(Xml) ->
         ?xpath_attr_required("/saml:Assertion/@Version", esaml_assertion, version, bad_version),
         ?xpath_attr_required("/saml:Assertion/@IssueInstant", esaml_assertion, issue_instant, bad_assertion),
         ?xpath_attr_required("/saml:Assertion/saml:Subject/saml:SubjectConfirmation/saml:SubjectConfirmationData/@Recipient", esaml_assertion, recipient, bad_recipient),
+        ?xpath_attr("/saml:Assertion/saml:Subject/saml:SubjectConfirmation/saml:SubjectConfirmationData/@InResponseTo", esaml_assertion, in_response_to),
         ?xpath_text("/saml:Assertion/saml:Issuer/text()", esaml_assertion, issuer),
         ?xpath_recurse("/saml:Assertion/saml:Subject", esaml_assertion, subject, decode_assertion_subject),
         ?xpath_recurse("/saml:Assertion/saml:Conditions", esaml_assertion, conditions, decode_assertion_conditions),
@@ -351,11 +354,27 @@ check_stale(A) ->
 -spec validate_assertion(AssertionXml :: #xmlElement{}, Recipient :: string(), Audience :: string()) ->
         {ok, #esaml_assertion{}} | {error, Reason :: term()}.
 validate_assertion(AssertionXml, Recipient, Audience) ->
+    validate_assertion(AssertionXml, Recipient, Audience,
+                      fun(_) -> ok end).
+
+-spec validate_assertion(AssertionXml :: #xmlElement{}, Recipient :: string(), Audience :: string(), IdFun :: esaml_sp:check_id_fun()) ->
+        {ok, #esaml_assertion{}} | {error, Reason :: term()}.
+validate_assertion(AssertionXml, Recipient, Audience, IdFun) ->
     case decode_assertion(AssertionXml) of
         {error, Reason} ->
             {error, Reason};
         {ok, Assertion} ->
             esaml_util:threaduntil([
+                fun(A) -> case A of
+                    % no InResponseTo is ok
+                    #esaml_assertion{in_response_to = undefined} -> A;
+                    % if there is one, however, it better be one we expect
+                    #esaml_assertion{in_response_to = Id} ->
+                        case IdFun(Id) of
+                            true -> A;
+                            _ -> {error, bad_in_response_to}
+                        end
+                end end,
                 fun(A) -> case A of
                     #esaml_assertion{version = "2.0"} -> A;
                     _ -> {error, bad_version}
@@ -578,6 +597,11 @@ decode_response_status_test() ->
     Resp = decode_response(Doc),
     {ok, #esaml_response{issue_instant = "2013-01-01T01:01:01Z", status = success, issuer = "foo"}} = Resp.
 
+decode_response_with_inresponseto_test() ->
+    {Doc, _} = xmerl_scan:string("<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" Version=\"2.0\" IssueInstant=\"2013-01-01T01:01:01Z\" InResponseTo=\"_4faf1ab5bd587d92145ad446e142c652\"><saml:Issuer>foo</saml:Issuer><samlp:Status><samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:Success\" /></samlp:Status></samlp:Response>", [{namespace_conformant, true}]),
+    Resp = decode_response(Doc),
+    {ok, #esaml_response{issue_instant = "2013-01-01T01:01:01Z", status = success, issuer = "foo", in_response_to="_4faf1ab5bd587d92145ad446e142c652"}} = Resp.
+
 decode_response_bad_assertion_test() ->
     {Doc, _} = xmerl_scan:string("<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" Version=\"2.0\" IssueInstant=\"2013-01-01T01:01:01Z\"><saml:Issuer>foo</saml:Issuer><samlp:Status><samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:Success\" /></samlp:Status><saml:Assertion></saml:Assertion></samlp:Response>", [{namespace_conformant, true}]),
     Resp = decode_response(Doc),
@@ -589,9 +613,9 @@ decode_assertion_no_recipient_test() ->
     {error, bad_recipient} = Resp.
 
 decode_assertion_test() ->
-    {Doc, _} = xmerl_scan:string("<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" Version=\"2.0\" IssueInstant=\"2013-01-01T01:01:01Z\"><saml:Issuer>foo</saml:Issuer><samlp:Status><samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:Success\" /></samlp:Status><saml:Assertion Version=\"2.0\" IssueInstant=\"test\"><saml:Issuer>foo</saml:Issuer><saml:Subject><saml:NameID>foobar</saml:NameID><saml:SubjectConfirmation Method=\"urn:oasis:names:tc:SAML:2.0:cm:bearer\"><saml:SubjectConfirmationData Recipient=\"foobar123\" /></saml:SubjectConfirmation></saml:Subject></saml:Assertion></samlp:Response>", [{namespace_conformant, true}]),
+    {Doc, _} = xmerl_scan:string("<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" Version=\"2.0\" IssueInstant=\"2013-01-01T01:01:01Z\" InResponseTo=\"_4faf1ab5bd587d92145ad446e142c652\"><saml:Issuer>foo</saml:Issuer><samlp:Status><samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:Success\" /></samlp:Status><saml:Assertion Version=\"2.0\" IssueInstant=\"test\"><saml:Issuer>foo</saml:Issuer><saml:Subject><saml:NameID>foobar</saml:NameID><saml:SubjectConfirmation Method=\"urn:oasis:names:tc:SAML:2.0:cm:bearer\"><saml:SubjectConfirmationData Recipient=\"foobar123\" InResponseTo=\"_4faf1ab5bd587d92145ad446e142c652\"/></saml:SubjectConfirmation></saml:Subject></saml:Assertion></samlp:Response>", [{namespace_conformant, true}]),
     Resp = decode_response(Doc),
-    {ok, #esaml_response{issue_instant = "2013-01-01T01:01:01Z", issuer = "foo", status = success, assertion = #esaml_assertion{issue_instant = "test", issuer = "foo", recipient = "foobar123", subject = #esaml_subject{name = "foobar", confirmation_method = bearer}}}} = Resp.
+    {ok, #esaml_response{issue_instant = "2013-01-01T01:01:01Z", issuer = "foo", status = success, in_response_to = "_4faf1ab5bd587d92145ad446e142c652", assertion = #esaml_assertion{issue_instant = "test", issuer = "foo", recipient = "foobar123", subject = #esaml_subject{name = "foobar", confirmation_method = bearer}, in_response_to = "_4faf1ab5bd587d92145ad446e142c652"}}} = Resp.
 
 decode_conditions_test() ->
     {Doc, _} = xmerl_scan:string("<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" Version=\"2.0\" IssueInstant=\"2013-01-01T01:01:01Z\"><saml:Issuer>foo</saml:Issuer><samlp:Status><samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:Success\" /></samlp:Status><saml:Assertion Version=\"2.0\" IssueInstant=\"test\"><saml:Issuer>foo</saml:Issuer><saml:Subject><saml:NameID>foobar</saml:NameID><saml:SubjectConfirmation Method=\"urn:oasis:names:tc:SAML:2.0:cm:bearer\"><saml:SubjectConfirmationData Recipient=\"foobar123\" /></saml:SubjectConfirmation></saml:Subject><saml:Conditions NotBefore=\"before\" NotOnOrAfter=\"notafter\"><saml:AudienceRestriction><saml:Audience>foobaraudience</saml:Audience></saml:AudienceRestriction></saml:Conditions></saml:Assertion></samlp:Response>", [{namespace_conformant, true}]),

--- a/src/esaml_sp.erl
+++ b/src/esaml_sp.erl
@@ -12,27 +12,40 @@
 -include("esaml.hrl").
 -include_lib("xmerl/include/xmerl.hrl").
 
--export([setup/1, generate_authn_request/3, generate_metadata/1]).
--export([validate_assertion/2, validate_assertion/3]).
+-export([setup/1, generate_authn_request/3, generate_authn_request/4, generate_metadata/1]).
+-export([validate_assertion/2, validate_assertion/3, validate_assertion/4]).
 -export([generate_logout_request/3, generate_logout_response/3]).
 -export([validate_logout_request/2, validate_logout_response/2]).
 
 -type xml() :: #xmlElement{} | #xmlDocument{}.
 -type dupe_fun() :: fun((esaml:assertion(), Digest :: binary()) -> ok | term()).
--export_type([dupe_fun/0]).
+-type generate_id_fun() :: fun(() -> binary()).
+-type check_id_fun() :: fun((string()) -> boolean()).
+-export_type([dupe_fun/0, check_id_fun/0]).
 
 %% @private
 -spec add_xml_id(xml()) -> xml().
 add_xml_id(Xml) ->
+    add_xml_id(Xml, fun esaml_util:unique_id/0).
+
+%% @private
+-spec add_xml_id(xml(), generate_id_fun()) -> xml().
+add_xml_id(Xml, IdFun) ->
+    UniqueId = IdFun(),
     Xml#xmlElement{attributes = Xml#xmlElement.attributes ++ [
         #xmlAttribute{name = 'ID',
-            value = esaml_util:unique_id(),
+            value = UniqueId,
             namespace = #xmlNamespace{}}
         ]}.
 
 %% @doc Return an AuthnRequest as an XML element
 -spec generate_authn_request(IdpURL :: string(), NameIDFormat :: string() | undefined, esaml:sp()) -> #xmlElement{}.
-generate_authn_request(IdpURL, NameIDFormat, SP = #esaml_sp{metadata_uri = MetaURI, consume_uri = ConsumeURI}) ->
+generate_authn_request(IdpURL, NameIDFormat, SP) ->
+    generate_authn_request(IdpURL, NameIDFormat, fun esaml_util:unique_id/0, SP).
+
+%% @doc Return an AuthnRequest as an XML element
+-spec generate_authn_request(IdpURL :: string(), NameIDFormat :: string() | undefined, generate_id_fun(), esaml:sp()) -> #xmlElement{}.
+generate_authn_request(IdpURL, NameIDFormat, IdFun, SP = #esaml_sp{metadata_uri = MetaURI, consume_uri = ConsumeURI}) ->
     Now = erlang:localtime_to_universaltime(erlang:localtime()),
     Stamp = esaml_util:datetime_to_saml(Now),
 
@@ -44,7 +57,7 @@ generate_authn_request(IdpURL, NameIDFormat, SP = #esaml_sp{metadata_uri = MetaU
     if SP#esaml_sp.sp_sign_requests ->
         xmerl_dsig:sign(Xml, SP#esaml_sp.key, SP#esaml_sp.certificate);
     true ->
-        add_xml_id(Xml)
+        add_xml_id(Xml, IdFun)
     end.
 
 %% @doc Return a LogoutRequest as an XML element
@@ -189,13 +202,18 @@ validate_logout_response(Xml, SP = #esaml_sp{}) ->
 validate_assertion(Xml, SP = #esaml_sp{}) ->
     validate_assertion(Xml, fun(_A, _Digest) -> ok end, SP).
 
+-spec validate_assertion(xml(), dupe_fun(), esaml:sp()) ->
+        {ok, esaml:assertion()} | {error, Reason :: term()}.
+validate_assertion(Xml, DuplicateFun, SP = #esaml_sp{}) ->
+    validate_assertion(Xml, DuplicateFun, fun(_A) -> true end, SP).
+
 %% @doc Validate and decode an assertion envelope in parsed XML
 %%
 %% The dupe_fun argument is intended to detect duplicate assertions
 %% in the case of a replay attack.
--spec validate_assertion(xml(), dupe_fun(), esaml:sp()) ->
+-spec validate_assertion(xml(), dupe_fun(), check_id_fun(), esaml:sp()) ->
         {ok, esaml:assertion()} | {error, Reason :: term()}.
-validate_assertion(Xml, DuplicateFun, SP = #esaml_sp{}) ->
+validate_assertion(Xml, DuplicateFun, IdFun, SP = #esaml_sp{}) ->
     Ns = [{"samlp", 'urn:oasis:names:tc:SAML:2.0:protocol'},
           {"saml", 'urn:oasis:names:tc:SAML:2.0:assertion'}],
     esaml_util:threaduntil([
@@ -224,7 +242,7 @@ validate_assertion(Xml, DuplicateFun, SP = #esaml_sp{}) ->
             end
         end,
         fun(A) ->
-            case esaml:validate_assertion(A, SP#esaml_sp.consume_uri, SP#esaml_sp.metadata_uri) of
+            case esaml:validate_assertion(A, SP#esaml_sp.consume_uri, SP#esaml_sp.metadata_uri, IdFun) of
                 {ok, AR} -> AR;
                 {error, Reason} -> {error, Reason}
             end


### PR DESCRIPTION
- Add ets table for tracking request ID's.
- When generating an authn request, generate unique ID and store it for
  a certain time (5 minutes).
- When validating an assertion response, verify that the ID in
  `InResponseTo` (if present) matches one we know; then forget that one.

Note that both `#esaml_response{}` and `#esaml_assertion{}` get an
`in_response_to` field: the ID is present in _both_ subtrees of the XML
document; but for validating an assertion response, only esaml_assertion
is used.

I've seen to it that the introduction of this feature is seamless, so when this is checked out locally into `deps/esaml`, the "old usage" of esaml is still supported -- by not tracking IDs.
